### PR TITLE
Enables search by working groups and areas of interest

### DIFF
--- a/app/helpers/decidim/members/members_helper.rb
+++ b/app/helpers/decidim/members/members_helper.rb
@@ -1,0 +1,17 @@
+module Decidim
+  module Members
+    # Helpers related to the Assemblies filter by type.
+    #
+    # `filter` returns a Filter object from Decidim::FilterResource
+    module MembersHelper
+      def options_for_state_filter
+        [["all", "All"], ["grantmaking", "Grantmaking"], ["community_building", "Community Building"], ["fundraising", "Fundraising"], ["communications", "Communications"], ["none", "None"]]
+      end
+
+      def options_for_areas_of_interest_filter
+        [["all", "All"], ["alt_economies", "Alt economies"], ["democratic_innovation", "Democratic Innovation"], ["digital_activism", "Digital Activism"], ["public_space", "Public Space"], ["feminism", "Feminism"], ["civil_rights", "Civil Rights"], ["alt_media", "Alt Media"], ["anti_discrimination", "Anti Discrimination"], ["migration", "Migration"], ["climate_justice", "Climate Justice"], ["public_health", "Public Health"]]
+      end
+
+    end
+  end
+end

--- a/app/queries/decidim/members/member_search.rb
+++ b/app/queries/decidim/members/member_search.rb
@@ -1,0 +1,46 @@
+# frozen_string_literal: true
+
+module Decidim
+  module Members
+    class MemberSearch < Rectify::Query
+      def initialize(organization, filters)
+        @organization = organization
+        @filters = filters
+        unless @filters.nil?
+          @search_text = filters[:search_text] 
+          @working_groups = filters[:working_groups] 
+          @areas_of_interest = filters[:areas_of_interest] 
+        end
+      end
+
+      def query
+        search = active_users
+        unless @filters.nil?
+          search = search_text(search) if @search_text.present?
+          search = working_groups_only(search) if @working_groups.present? && (@working_groups != "all")
+          search = areas_of_interest_only(search) if @areas_of_interest.present? && (@areas_of_interest != "all")
+        end
+
+        search
+      end
+
+      private
+
+      def active_users
+        @organization.users.not_deleted.no_active_invitation.order(name: :asc)
+      end
+
+      def search_text(search)
+        search.where("name ILIKE ?", "%" + Decidim::User.sanitize_sql_like(@search_text)  + "%")
+      end
+
+      def working_groups_only(search)
+        search.where("profile -> 'working_groups' ? :working_groups", working_groups: @working_groups)
+      end
+
+      def areas_of_interest_only(search)
+        search.where("profile -> 'areas_of_interest' ? :areas_of_interest", areas_of_interest: @areas_of_interest)
+      end
+    end
+  end
+end

--- a/app/views/decidim/members/members/_count.html.erb
+++ b/app/views/decidim/members/members/_count.html.erb
@@ -1,0 +1,5 @@
+<% if params[:filter].present? %>
+  <%= t "members.index.members_found", scope: "decidim", count: count %>
+<% else %>
+  <%= t "members.index.members", scope: "decidim", count: count %>
+<% end %>

--- a/app/views/decidim/members/members/_filters.html.erb
+++ b/app/views/decidim/members/members/_filters.html.erb
@@ -1,0 +1,35 @@
+<%= render partial: "decidim/shared/filter_form_help", locals: { skip_to_id: "members" } %>
+
+<%= filter_form_for filter do |form| %>
+  <div class="filters__section">
+    <div class="filters__search">
+      <div class="input-group">
+        <%= form.search_field :search_text,
+                              label: false,
+                              class: "input-group-field",
+                              placeholder: "buscar",
+                              title: "buscar titulo",
+                              data: { disable_dynamic_change: true } %>
+        <div class="input-group-button">
+          <button type="submit" class="button" aria-controls="members">
+            <%= icon "magnifying-glass", aria_label: "Search", role: "img" %>
+          </button>
+        </div>
+      </div>
+    </div>
+  </div>
+
+  <%= form.collection_radio_buttons :working_groups,
+                                    options_for_state_filter,
+                                    :first,
+                                    :last,
+                                    { legend_title: "Working Groups"},
+                                    "aria-controls": "members" %>
+  <%= form.collection_radio_buttons :areas_of_interest,
+                                    options_for_areas_of_interest_filter,
+                                    :first,
+                                    :last,
+                                    { legend_title: "Areas of interest"},
+                                    "aria-controls": "members" %>
+
+<% end %>

--- a/app/views/decidim/members/members/_members.html.erb
+++ b/app/views/decidim/members/members/_members.html.erb
@@ -1,0 +1,2 @@
+<%= members.render_current_page %>
+<%= members.render_pagination %>

--- a/app/views/decidim/members/members/index.html.erb
+++ b/app/views/decidim/members/members/index.html.erb
@@ -1,35 +1,27 @@
 <% provide :meta_title, t("members.index.title", scope: "decidim") %>
 
 <main class="wrapper">
-  <section id="members-grid" class="section row collapse">
-    <div class="row collapse order-by">
-      <% if @members.query.present? %>
-        <h2 class="order-by__text section-heading"><%= t "members.index.members_found", scope: "decidim", count: @members.count %></h2>
+  <div class="row">
+    <div class="columns mediumlarge-4 large-3">
+      <div class="card card--secondary show-for-mediumlarge">
+        <%= render partial: "filters" %>
+      </div>
+    </div>
+    <div class="columns mediumlarge-8 large-9">
+      <section id="members-grid" class="section row collapse">
+        <div class="row collapse order-by">
+          <h2 id="members-count" class="order-by__text section-heading">
+          <%= render partial: "count", locals: { count: @members.count, params: @members.params } %>
+          </h2>
           <span style="margin-left: 1em;">(<%= link_to t("members.index.show_all", scope: "decidim"), decidim_members.members_path %>)</span>
-      <% else %>
-        <h2 class="order-by__text section-heading"><%= t "members.index.members", scope: "decidim", count: @members.count %></h2>
-      <% end %>
-    </div>
-
-    <div class="row" style="margin-bottom: 3em;">
-
-      <%= form_tag({}, id: 'member-search', method: :get) do %>
-        <div class="input-group" style="width: 50%; margin: auto;">
-          <%= text_field_tag :q, @members.query, placeholder: 'Search', class: 'input-group-field' %>
-          <div class="input-group-button">
-            <button type="submit" class="button button--muted">
-              <%= icon "magnifying-glass", aria_label: t('members.index.search', scope: 'decidim') %>
-            </button>
-          </div>
         </div>
-      <% end %>
-
+        <div id="members" class="row small-up-1 medium-up-2 large-up-3 card-grid">
+          <%= render partial: "members", locals: { members: @members } %>
+        </div>
+      </section>
     </div>
-
-    <div class="row small-up-1 medium-up-2 large-up-3 card-grid">
-      <%= @members.render_current_page %>
-    </div>
-  </section>
-  <%= @members.render_pagination %>
+  </div>
 </main>
 
+<%= javascript_include_tag "decidim/filters" %>
+<%= javascript_include_tag "decidim/results_listing" %>

--- a/app/views/decidim/members/members/index.js.erb
+++ b/app/views/decidim/members/members/index.js.erb
@@ -1,0 +1,9 @@
+var $members = $('#members');
+var $membersCount = $('#members-count');
+var $orderFilterInput = $('.order_filter');
+
+$members.html('<%= j(render partial: "members", locals: { members: @members }) %>');
+$membersCount.html('<%= j(render partial: "count", locals: { count: @members.count}) %>');
+
+
+


### PR DESCRIPTION
This PR enables users to search by profile["working_groups"] and profile["areas_of_interest"]. It changes the following:

- Changes search strategy from Decidim::Search to a Rectify::Query and simple ActiveRecord queries, as the former does not support easily other Decidim::Users attributes (Decidim::Search is built to search mainly by Decidim::Component and hacking it to do this results in overengineering)
- Uses the Decidim::FiltersHelper to build the search form on top of shared Decidim components for search and filtering
- Reworks the views to enable the helper to work properly